### PR TITLE
Add support to new Azure Cognitive Services API

### DIFF
--- a/src/main/java/com/memetix/mst/detect/Detect.java
+++ b/src/main/java/com/memetix/mst/detect/Detect.java
@@ -48,8 +48,7 @@ public final class Detect extends MicrosoftTranslatorAPI {
 	public static Language execute(final String text) throws Exception {
         //Run the basic service validations first
         validateServiceState(text); 
-		final URL url = new URL(SERVICE_URL 
-                        +(apiKey != null ? PARAM_APP_ID + URLEncoder.encode(apiKey,ENCODING) : "") 
+		final URL url = new URL(SERVICE_URL
                         +PARAM_TEXT_SINGLE+URLEncoder.encode(text, ENCODING));
                      
 		final String response = retrieveString(url);
@@ -67,8 +66,7 @@ public final class Detect extends MicrosoftTranslatorAPI {
         //Run the basic service validations first
         validateServiceState(texts); 
         final String textArr = buildStringArrayParam(texts);
-		final URL url = new URL(ARRAY_SERVICE_URL 
-                        +(apiKey != null ? PARAM_APP_ID + URLEncoder.encode(apiKey,ENCODING) : "") 
+		final URL url = new URL(ARRAY_SERVICE_URL
                         +PARAM_TEXT_ARRAY+URLEncoder.encode(textArr, ENCODING));
 		final String[] response = retrieveStringArr(url);
                 return response;

--- a/src/main/java/com/memetix/mst/language/Language.java
+++ b/src/main/java/com/memetix/mst/language/Language.java
@@ -114,13 +114,7 @@ public enum Language {
             LanguageService.setKey(pKey);
         }
         
-        public static void setClientId(String pId) {
-            LanguageService.setClientId(pId);
-        }
-        public static void setClientSecret(String pSecret) {
-            LanguageService.setClientSecret(pSecret);
-        }
-        
+
 		/**
 		 * getName()
 		 * 
@@ -221,7 +215,6 @@ public enum Language {
                 final String targetString = buildStringArrayParam(Language.values());
                 
                 final URL url = new URL(SERVICE_URL 
-                        +(apiKey != null ? PARAM_APP_ID + URLEncoder.encode(apiKey,ENCODING) : "") 
                         +PARAM_LOCALE+URLEncoder.encode(locale.toString(), ENCODING)
                         +PARAM_LANGUAGE_CODES + URLEncoder.encode(targetString, ENCODING));
                 localizedNames = retrieveStringArr(url);
@@ -245,7 +238,7 @@ public enum Language {
                 validateServiceState(); 
                 String[] codes = new String[0];
                 
-                final URL url = new URL(SERVICE_URL +(apiKey != null ? PARAM_APP_ID + URLEncoder.encode(apiKey,ENCODING) : ""));
+                final URL url = new URL(SERVICE_URL);
                 codes = retrieveStringArr(url);
                 return codes;
         }

--- a/src/main/java/com/memetix/mst/language/SpokenDialect.java
+++ b/src/main/java/com/memetix/mst/language/SpokenDialect.java
@@ -98,14 +98,7 @@ public enum SpokenDialect {
             SpokenDialectService.setKey(pKey);
         }
         
-        public static void setClientId(String pId) {
-            SpokenDialectService.setClientId(pId);
-        }
-        
-        public static void setClientSecret(String pSecret) {
-            SpokenDialectService.setClientSecret(pSecret);
-        }
-        
+
     /**
      * getName()
      * 
@@ -172,7 +165,6 @@ public enum SpokenDialect {
 	                final String targetString = buildStringArrayParam(SpokenDialect.values());
 	
 	                final URL url = new URL(SERVICE_URL 
-	                        +(apiKey != null ? PARAM_APP_ID + URLEncoder.encode(apiKey,ENCODING) : "") 
 	                        +PARAM_LOCALE+URLEncoder.encode(locale.toString(), ENCODING)
 	                        +PARAM_LANGUAGE_CODES + URLEncoder.encode(targetString, ENCODING));
 	                localizedNames = retrieveStringArr(url);

--- a/src/main/java/com/memetix/mst/sentence/BreakSentences.java
+++ b/src/main/java/com/memetix/mst/sentence/BreakSentences.java
@@ -53,7 +53,6 @@ public final class BreakSentences extends MicrosoftTranslatorAPI {
         //Run the basic service validations first
         validateServiceState(text,fromLang); 
 		final URL url = new URL(SERVICE_URL 
-                        +(apiKey != null ? PARAM_APP_ID + URLEncoder.encode(apiKey,ENCODING) : "") 
                         +PARAM_SENTENCES_LANGUAGE+URLEncoder.encode(fromLang.toString(), ENCODING)
                         +PARAM_TEXT_SINGLE+URLEncoder.encode(text, ENCODING));
                      

--- a/src/main/java/com/memetix/mst/speak/Speak.java
+++ b/src/main/java/com/memetix/mst/speak/Speak.java
@@ -50,7 +50,6 @@ public final class Speak extends MicrosoftTranslatorAPI {
                 //Run the basic service validations first
                 validateServiceState(text);             
 		final URL url = new URL(SERVICE_URL 
-                        +(apiKey != null ? PARAM_APP_ID + URLEncoder.encode(apiKey,ENCODING) : "") 
                         +PARAM_SPOKEN_LANGUAGE+URLEncoder.encode(language.toString(),ENCODING)
                         +PARAM_TEXT_SINGLE+URLEncoder.encode(text, ENCODING));
 		final String response = retrieveString(url);

--- a/src/main/java/com/memetix/mst/translate/Translate.java
+++ b/src/main/java/com/memetix/mst/translate/Translate.java
@@ -52,13 +52,12 @@ public final class Translate extends MicrosoftTranslatorAPI {
         //Run the basic service validations first
         validateServiceState(text); 
         final String params = 
-                (apiKey != null ? PARAM_APP_ID + URLEncoder.encode(apiKey,ENCODING) : "") 
-                + PARAM_FROM_LANG + URLEncoder.encode(from.toString(),ENCODING) 
+                PARAM_FROM_LANG + URLEncoder.encode(from.toString(),ENCODING)
                 + PARAM_TO_LANG + URLEncoder.encode(to.toString(),ENCODING) 
                 + PARAM_TEXT_SINGLE + URLEncoder.encode(text,ENCODING);
         
         final URL url = new URL(SERVICE_URL + params);
-    	final String response = retrieveString(url);
+        final String response = retrieveString(url);
     	return response;
     }
     
@@ -92,8 +91,7 @@ public final class Translate extends MicrosoftTranslatorAPI {
         //Run the basic service validations first
         validateServiceState(texts); 
         final String params = 
-                (apiKey != null ? PARAM_APP_ID + URLEncoder.encode(apiKey,ENCODING) : "") 
-                + PARAM_FROM_LANG + URLEncoder.encode(from.toString(),ENCODING) 
+                  PARAM_FROM_LANG + URLEncoder.encode(from.toString(),ENCODING)
                 + PARAM_TO_LANG + URLEncoder.encode(to.toString(),ENCODING) 
                 + PARAM_TEXT_ARRAY + URLEncoder.encode(buildStringArrayParam(texts),ENCODING);
         
@@ -112,7 +110,6 @@ public final class Translate extends MicrosoftTranslatorAPI {
      * execute(texts[],fromLang,toLang)
      * 
      * @param texts The Strings Array to translate.
-     * @param from The language code to translate from.
      * @param to The language code to translate to.
      * @return The translated Strings Array[].
      * @throws Exception on error.

--- a/src/test/java/com/memetix/mst/detect/DetectTest.java
+++ b/src/test/java/com/memetix/mst/detect/DetectTest.java
@@ -43,20 +43,10 @@ public class DetectTest {
         p = new Properties();
         URL url = ClassLoader.getSystemResource("META-INF/config.properties");
         p.load(url.openStream());
-        String apiKey = p.getProperty("microsoft.translator.api.key");
+        String apiKey = p.getProperty("microsoft.azure.subscription.key");
         if(System.getProperty("test.api.key")!=null) {
             apiKey = System.getProperty("test.api.key").split(",")[0];
         }
-        String clientId = p.getProperty("microsoft.translator.api.clientId");
-        if(System.getProperty("test.api.key")!=null) {
-            clientId = System.getProperty("test.api.key").split(",")[1];
-        }
-        String clientSecret = p.getProperty("microsoft.translator.api.clientSecret");
-        if(System.getProperty("test.api.key")!=null) {
-            clientSecret = System.getProperty("test.api.key").split(",")[2];
-        }
-        Detect.setClientId(clientId);
-        Detect.setClientSecret(clientSecret);
         Detect.setKey(apiKey);
     }
     
@@ -102,37 +92,33 @@ public class DetectTest {
     @Test
     public void testDetect_WrongKey() throws Exception {
         Detect.setKey("wrong_key");
-        Detect.setClientId(null);
         exception.expect(RuntimeException.class);
-        exception.expectMessage("INVALID_API_KEY - Please set the API Key with your Bing Developer's Key");
+        exception.expectMessage("INVALID_API_KEY - Please set the API Key with your Azure Subscription Key");
         Detect.execute("전 세계 여러분 안녕하세요");
     }
     
     @Test
     public void testDetect_NoKey() throws Exception {
         Detect.setKey(null);
-        Detect.setClientId(null);
         exception.expect(RuntimeException.class);
-        exception.expectMessage("Must provide a Windows Azure Marketplace Client Id and Client Secret - Please see http://msdn.microsoft.com/en-us/library/hh454950.aspx for further documentation");
+        exception.expectMessage("Must provide a Windows Azure Subscription Key - Please see https://www.microsoft.com/en-us/translator/getstarted.aspx for further documentation");
         Detect.execute("전 세계 여러분 안녕하세요");
     }
     @Test
     public void testDetectArray_NoKey() throws Exception {
         Detect.setKey(null);
-        Detect.setClientId(null);
         String[] texts = {"Hello world!"};
         exception.expect(RuntimeException.class);
-        exception.expectMessage("Must provide a Windows Azure Marketplace Client Id and Client Secret - Please see http://msdn.microsoft.com/en-us/library/hh454950.aspx for further documentation");
+        exception.expectMessage("Must provide a Windows Azure Subscription Key - Please see https://www.microsoft.com/en-us/translator/getstarted.aspx for further documentation");
         Detect.execute(texts);
     }
     
     @Test
     public void testDetectArray_WrongKey() throws Exception {
         Detect.setKey("wrong_key");
-        Detect.setClientId(null);
         String[] texts = {"Hello world!"};
         exception.expect(RuntimeException.class);
-        exception.expectMessage("INVALID_API_KEY - Please set the API Key with your Bing Developer's Key");
+        exception.expectMessage("INVALID_API_KEY - Please set the API Key with your Azure Subscription Key");
         Detect.execute(texts);
     }
 

--- a/src/test/java/com/memetix/mst/language/LanguageTest.java
+++ b/src/test/java/com/memetix/mst/language/LanguageTest.java
@@ -47,20 +47,10 @@ public class LanguageTest {
         p = new Properties();
         URL url = ClassLoader.getSystemResource("META-INF/config.properties");
         p.load(url.openStream());
-        String apiKey = p.getProperty("microsoft.translator.api.key");
+        String apiKey = p.getProperty("microsoft.azure.subscription.key");
         if(System.getProperty("test.api.key")!=null) {
             apiKey = System.getProperty("test.api.key").split(",")[0];
         }
-        String clientId = p.getProperty("microsoft.translator.api.clientId");
-        if(System.getProperty("test.api.key")!=null) {
-            clientId = System.getProperty("test.api.key").split(",")[1];
-        }
-        String clientSecret = p.getProperty("microsoft.translator.api.clientSecret");
-        if(System.getProperty("test.api.key")!=null) {
-            clientSecret = System.getProperty("test.api.key").split(",")[2];
-        }
-        Language.setClientId(clientId);
-        Language.setClientSecret(clientSecret);
         Language.setKey(apiKey);
     }
     
@@ -103,11 +93,10 @@ public class LanguageTest {
     @Test
     public void testGetLanguage_NoKey() throws Exception {
         Language.setKey(null);
-        Language.setClientId(null);
         Language locale = Language.PERSIAN;
         
         exception.expect(RuntimeException.class);
-        exception.expectMessage("Must provide a Windows Azure Marketplace Client Id and Client Secret - Please see http://msdn.microsoft.com/en-us/library/hh454950.aspx for further documentation");
+        exception.expectMessage("Must provide a Windows Azure Subscription Key - Please see https://www.microsoft.com/en-us/translator/getstarted.aspx for further documentation");
         Language.FRENCH.getName(locale);
     }
     
@@ -117,7 +106,7 @@ public class LanguageTest {
         Language locale = Language.PERSIAN;
         
         exception.expect(RuntimeException.class);
-        exception.expectMessage("INVALID_API_KEY - Please set the API Key with your Bing Developer's Key");
+        exception.expectMessage("INVALID_API_KEY - Please set the API Key with your Azure Subscription Key");
         Language.FRENCH.getName(locale);
     }
 

--- a/src/test/java/com/memetix/mst/language/SpokenDialectTest.java
+++ b/src/test/java/com/memetix/mst/language/SpokenDialectTest.java
@@ -45,21 +45,11 @@ public class SpokenDialectTest {
         p = new Properties();
         URL url = ClassLoader.getSystemResource("META-INF/config.properties");
         p.load(url.openStream());
-        String apiKey = p.getProperty("microsoft.translator.api.key");
+        String apiKey = p.getProperty("microsoft.azure.subscription.key");
         if(System.getProperty("test.api.key")!=null) {
             apiKey = System.getProperty("test.api.key").split(",")[0];
         }
-        String clientId = p.getProperty("microsoft.translator.api.clientId");
-        if(System.getProperty("test.api.key")!=null) {
-            clientId = System.getProperty("test.api.key").split(",")[1];
-        }
-        String clientSecret = p.getProperty("microsoft.translator.api.clientSecret");
-        if(System.getProperty("test.api.key")!=null) {
-            clientSecret = System.getProperty("test.api.key").split(",")[2];
-        }
         SpokenDialect.setKey(apiKey);
-        SpokenDialect.setClientId(clientId);
-        SpokenDialect.setClientSecret(clientSecret);
     }
     
     @After
@@ -71,11 +61,10 @@ public class SpokenDialectTest {
     public void testGetSpokenDialect_NoKey() throws Exception {
         SpokenDialect.flushNameCache();
         SpokenDialect.setKey(null);
-        SpokenDialect.setClientId(null);
         Language locale = Language.ENGLISH;
         
         exception.expect(RuntimeException.class);
-        exception.expectMessage("Must provide a Windows Azure Marketplace Client Id and Client Secret - Please see http://msdn.microsoft.com/en-us/library/hh454950.aspx for further documentation");
+        exception.expectMessage("Must provide a Windows Azure Subscription Key - Please see https://www.microsoft.com/en-us/translator/getstarted.aspx for further documentation");
         SpokenDialect.FRENCH_CANADA.getName(locale);
     }
     
@@ -86,7 +75,7 @@ public class SpokenDialectTest {
         Language locale = Language.ENGLISH;
         
         exception.expect(RuntimeException.class);
-        exception.expectMessage("INVALID_API_KEY - Please set the API Key with your Bing Developer's Key");
+        exception.expectMessage("INVALID_API_KEY - Please set the API Key with your Azure Subscription Key");
         SpokenDialect.FRENCH_CANADA.getName(locale);
     }
 

--- a/src/test/java/com/memetix/mst/sentence/BreakSentencesTest.java
+++ b/src/test/java/com/memetix/mst/sentence/BreakSentencesTest.java
@@ -42,21 +42,12 @@ public class BreakSentencesTest {
             p = new Properties();
             URL url = ClassLoader.getSystemResource("META-INF/config.properties");
             p.load(url.openStream());
-            String apiKey = p.getProperty("microsoft.translator.api.key");
+            String apiKey = p.getProperty("microsoft.azure.subscription.key");
             if(System.getProperty("test.api.key")!=null) {
                 apiKey = System.getProperty("test.api.key").split(",")[0];
             }
-            String clientId = p.getProperty("microsoft.translator.api.clientId");
-            if(System.getProperty("test.api.key")!=null) {
-                clientId = System.getProperty("test.api.key").split(",")[1];
-            }
-            String clientSecret = p.getProperty("microsoft.translator.api.clientSecret");
-            if(System.getProperty("test.api.key")!=null) {
-                clientSecret = System.getProperty("test.api.key").split(",")[2];
-            }
             BreakSentences.setKey(apiKey);
-            BreakSentences.setClientSecret(clientSecret);
-            BreakSentences.setClientId(clientId);
+
         }
 
 	@After
@@ -82,18 +73,17 @@ public class BreakSentencesTest {
 	@Test
         public void testBreakSentences_NoKey() throws Exception {
             BreakSentences.setKey(null);
-            BreakSentences.setClientId(null);
             exception.expect(RuntimeException.class);
-            exception.expectMessage("Must provide a Windows Azure Marketplace Client Id and Client Secret - Please see http://msdn.microsoft.com/en-us/library/hh454950.aspx for further documentation");
-            BreakSentences.execute("This is a sentence. That is a sentence. There are hopefully 3 sentences detected.",Language.ENGLISH);
+			exception.expectMessage("Must provide a Windows Azure Subscription Key - Please see https://www.microsoft.com/en-us/translator/getstarted.aspx for further documentation");
+			BreakSentences.execute("This is a sentence. That is a sentence. There are hopefully 3 sentences detected.",Language.ENGLISH);
 	}
-        @Test
-        public void testBreakSentences_WrongKey() throws Exception {
-            BreakSentences.setKey("wrong");
-            exception.expect(RuntimeException.class);
-            exception.expectMessage("INVALID_API_KEY - Please set the API Key with your Bing Developer's Key");
-            BreakSentences.execute("This is a sentence. That is a sentence. There are hopefully 3 sentences detected.",Language.ENGLISH);
-        }
+	@Test
+	public void testBreakSentences_WrongKey() throws Exception {
+		BreakSentences.setKey("wrong");
+		exception.expect(RuntimeException.class);
+		exception.expectMessage("INVALID_API_KEY - Please set the API Key with your Azure Subscription Key");
+		BreakSentences.execute("This is a sentence. That is a sentence. There are hopefully 3 sentences detected.",Language.ENGLISH);
+	}
 	
 	@Test
     public void testBreakSentencesEnglish_Large() throws Exception {

--- a/src/test/java/com/memetix/mst/speak/SpeakTest.java
+++ b/src/test/java/com/memetix/mst/speak/SpeakTest.java
@@ -44,21 +44,12 @@ public class SpeakTest {
         p = new Properties();
         URL url = ClassLoader.getSystemResource("META-INF/config.properties");
         p.load(url.openStream());
-        String apiKey = p.getProperty("microsoft.translator.api.key");
+        String apiKey = p.getProperty("microsoft.azure.subscription.key");
         if(System.getProperty("test.api.key")!=null) {
             apiKey = System.getProperty("test.api.key").split(",")[0];
         }
-        String clientId = p.getProperty("microsoft.translator.api.clientId");
-        if(System.getProperty("test.api.key")!=null) {
-            clientId = System.getProperty("test.api.key").split(",")[1];
-        }
-        String clientSecret = p.getProperty("microsoft.translator.api.clientSecret");
-        if(System.getProperty("test.api.key")!=null) {
-            clientSecret = System.getProperty("test.api.key").split(",")[2];
-        }
         Speak.setKey(apiKey);
-        Speak.setClientSecret(clientSecret);
-        Speak.setClientId(clientId);
+
     }
     
     @After
@@ -72,9 +63,8 @@ public class SpeakTest {
     @Test
     public void testGetSpeakUrl_NoKey() throws Exception {
         Speak.setKey(null);
-        Speak.setClientId(null);
         exception.expect(RuntimeException.class);
-        exception.expectMessage("Must provide a Windows Azure Marketplace Client Id and Client Secret - Please see http://msdn.microsoft.com/en-us/library/hh454950.aspx for further documentation");
+        exception.expectMessage("Must provide a Windows Azure Subscription Key - Please see https://www.microsoft.com/en-us/translator/getstarted.aspx for further documentation");
         String text = "Hello World!";
         SpokenDialect language = SpokenDialect.ENGLISH_INDIA;
         Speak.execute(text, language);

--- a/src/test/java/com/memetix/mst/token/GetTokenTest.java
+++ b/src/test/java/com/memetix/mst/token/GetTokenTest.java
@@ -1,0 +1,60 @@
+/*
+ * microsoft-translator-java-api
+ * 
+ * Copyright 2012 Jonathan Griggs <jonathan.griggs at gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.memetix.mst.token;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.net.URL;
+import java.util.Properties;
+
+import com.memetix.mst.MicrosoftTranslatorAPI;
+import com.memetix.mst.detect.Detect;
+import com.memetix.mst.language.Language;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * Unit Tests for the Auth Token
+ * @author Thomas Lehoux <tlehoux at gmail.com>
+ */
+public class GetTokenTest {
+    Properties p;
+
+    
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+    
+
+    @Test
+    public void testGetToken() throws Exception {
+
+        p = new Properties();
+        URL url = ClassLoader.getSystemResource("META-INF/config.properties");
+        p.load(url.openStream());
+        String apiKey = p.getProperty("microsoft.azure.subscription.key");
+        if(System.getProperty("test.api.key")!=null) {
+            apiKey = System.getProperty("test.api.key").split(",")[0];
+        }
+        assertNotNull(MicrosoftTranslatorAPI.getToken(apiKey));
+    }
+
+}

--- a/src/test/java/com/memetix/mst/translate/TranslateTest.java
+++ b/src/test/java/com/memetix/mst/translate/TranslateTest.java
@@ -46,29 +46,18 @@ public class TranslateTest{
         p = new Properties();
         URL url = ClassLoader.getSystemResource("META-INF/config.properties");
         p.load(url.openStream());
-        String apiKey = p.getProperty("microsoft.translator.api.key");
+        String apiKey = p.getProperty("microsoft.azure.subscription.key");
         if(System.getProperty("test.api.key")!=null) {
             apiKey = System.getProperty("test.api.key").split(",")[0];
         }
-        String clientId = p.getProperty("microsoft.translator.api.clientId");
-        if(System.getProperty("test.api.key")!=null) {
-            clientId = System.getProperty("test.api.key").split(",")[1];
-        }
-        String clientSecret = p.getProperty("microsoft.translator.api.clientSecret");
-        if(System.getProperty("test.api.key")!=null) {
-            clientSecret = System.getProperty("test.api.key").split(",")[2];
-        }
         Translate.setKey(apiKey);
-        Translate.setClientSecret(clientSecret);
-        Translate.setClientId(clientId);
+
     }
     
     @After
     public void tearDown() throws Exception {
         Translate.setKey(null);
         Translate.setContentType("text/plain");
-        Translate.setClientId(null);
-        Translate.setClientSecret(null);
         Translate.setHttpReferrer(null);
     }
 
@@ -162,26 +151,20 @@ public class TranslateTest{
     @Test
      public void testTranslate_NoKey() throws Exception {
         Translate.setKey(null);
-        Translate.setClientId(null);
-        Translate.setClientSecret(null);
         exception.expect(RuntimeException.class);
-        exception.expectMessage("Must provide a Windows Azure Marketplace Client Id and Client Secret - Please see http://msdn.microsoft.com/en-us/library/hh454950.aspx for further documentation");
+        exception.expectMessage("Must provide a Windows Azure Subscription Key - Please see https://www.microsoft.com/en-us/translator/getstarted.aspx for further documentation");
         Translate.execute("ハローワールド", Language.AUTO_DETECT, Language.ENGLISH);
     }
     @Test
      public void testTranslate_WrongKey() throws Exception {
-        Translate.setKey("lessthan16");
-        Translate.setClientId(null);
-        Translate.setClientSecret(null);
+        Translate.setKey("lessthan32");
         exception.expect(RuntimeException.class);
-        exception.expectMessage("INVALID_API_KEY - Please set the API Key with your Bing Developer's Key");
+        exception.expectMessage("INVALID_API_KEY - Please set the API Key with your Azure Subscription Key");
         Translate.execute("ハローワールド", Language.AUTO_DETECT, Language.ENGLISH);
     }
     
     @Test
      public void testTranslate_SetKeyNoClientIdAndSecret() throws Exception {
-        Translate.setClientId(null);
-        Translate.setClientSecret(null);
         String translate = Translate.execute("ハローワールド", Language.AUTO_DETECT, Language.ENGLISH);
         assertNotNull(translate);
     }

--- a/src/test/resources/META-INF/config.properties
+++ b/src/test/resources/META-INF/config.properties
@@ -1,2 +1,2 @@
-microsoft.translator.api.key=INSERT_API_KEY
+microsoft.azure.subscription.key=788da216872840108f902c63bf2ce739
  

--- a/src/test/resources/META-INF/config.properties
+++ b/src/test/resources/META-INF/config.properties
@@ -1,2 +1,2 @@
-microsoft.azure.subscription.key=788da216872840108f902c63bf2ce739
+microsoft.azure.subscription.key=YOUR_API_KEY
  


### PR DESCRIPTION
This pull request has been made in order to support for new Azure Cognitive Services API. The API calls are all the same except for how the 10-minute auth token is fetched.  It now uses a single api_key to fetch the token (instead of using a client_id and client_key).

More information here: 
https://blogs.msdn.microsoft.com/translation/2017/04/10/reminder-move-translator-api-subscriptions-from-datamarket-to-azure-before-april-30-2017/
